### PR TITLE
support for pushing upload and promote notifications to eventinator

### DIFF
--- a/lib/chef/knife/spork-promote.rb
+++ b/lib/chef/knife/spork-promote.rb
@@ -284,6 +284,8 @@ module KnifeSpork
               end 
             rescue Timeout::Error
               ui.warn("Timed out connecting to #{AppConf.eventinator.url} promote wasn't eventinated")
+            rescue Exception => msg 
+              ui.warn("An unhandled execption occured while eventinating: #{msg}")
             end 
           end
 

--- a/lib/chef/knife/spork-upload.rb
+++ b/lib/chef/knife/spork-upload.rb
@@ -167,6 +167,8 @@ module KnifeSpork
                 end 
               rescue Timeout::Error
                 ui.warn("Timed out connecting to #{AppConf.eventinator.url} upload wasn't eventinated")
+              rescue Exception => msg
+                ui.warn("An unhandled execption occured while eventinating: #{msg}")
               end 
             end 
 


### PR DESCRIPTION
upload and promote will send notifications to eventinator wrapped in config flag, only required param is the url which is the url to the event submission API endpoint

```
eventinator:
    enabled: true
    url: http://your.eventinator.server/endpoint
```
