### PR TITLE
correct usage notes of spork bump

### DIFF
--- a/lib/chef/knife/spork-bump.rb
+++ b/lib/chef/knife/spork-bump.rb
@@ -16,7 +16,7 @@ module KnifeSpork
 
     TYPE_INDEX = { "major" => 0, "minor" => 1, "patch" => 2, "manual" => 3 }
 
-    banner "knife spork bump COOKBOOK [MAJOR|MINOR|PATCH|MANUAL]"
+    banner "knife spork bump COOKBOOK [major|minor|patch|manual]"
 
       @@gitavail = true
       deps do


### PR DESCRIPTION
the usage notes say uppercase bump version, whereas the plugin actually wants it to be lower case
