### PR TITLE
fixes spork bump when bumping a cookbook that matches cookbook_path

### DIFF
--- a/lib/chef/knife/spork-bump.rb
+++ b/lib/chef/knife/spork-bump.rb
@@ -170,7 +170,7 @@ module KnifeSpork
     def git_add(cookbook)
       strio = StringIO.new
       l = Logger.new strio
-      cookbook_path = cookbook_repo[cookbook].root_dir.gsub("#{cookbook}","")
+      cookbook_path = cookbook_repo[cookbook].root_dir.gsub(/#{cookbook}$/,"")
       begin
         path = cookbook_path.gsub("/site-cookbooks","").gsub("/cookbooks","")
         ui.msg "Opening git repo #{path}\n\n"


### PR DESCRIPTION
Fixes an issue where cookbook_path is incorrectly stripped of all occurances of the cookbook name from the cookbook_path.

Example: attempting to bump a cookbook named `chef` located at `~/Sites/paperlesspost/paperless-chef/chef` previously failed because cookbook_path was evaluated as `~/Sites/paperlesspost/paperless-/`.

Now the regex will only match occurances at the end of the string and the cookbook_path will be `~/Sites/paperlesspost/paperless-chef/`.
