### PR TITLE
add require 'knife-spork/runner'

### DIFF
--- a/lib/chef/knife/spork-upload.rb
+++ b/lib/chef/knife/spork-upload.rb
@@ -2,6 +2,7 @@ require 'chef/knife'
 require 'chef/exceptions'
 require 'chef/cookbook_loader'
 require 'chef/cookbook_uploader'
+require 'knife-spork/runner'
 require 'socket'
 
 module KnifeSpork


### PR DESCRIPTION
This broke the plugin for me, since the Runner is included in the class but not actually required beforehand.
