### PR TITLE
cleaner check for new Chef cookbook upload API

### DIFF
--- a/lib/chef/knife/spork-upload.rb
+++ b/lib/chef/knife/spork-upload.rb
@@ -62,19 +62,15 @@ module KnifeSpork
       @cookbooks.reverse.each do |cookbook|
         begin
           check_dependencies(cookbook)
-          if Gem.loaded_specs['chef'].version == Gem::Version.create('10.14.0')
-            uploader = Chef::CookbookUploader.new([cookbook], ::Chef::Config.cookbook_path).upload_cookbooks
-            if name_args.include?(cookbook.name.to_s)
-              ui.info "Freezing #{cookbook.name} at #{cookbook.version}..."
-              cookbook.freeze_version
-              Chef::CookbookUploader.new(cookbook, ::Chef::Config.cookbook_path).upload_cookbooks
-            end
-          else
-            uploader = Chef::CookbookUploader.new(cookbook, ::Chef::Config.cookbook_path).upload_cookbook
-            if name_args.include?(cookbook.name.to_s)
-              ui.info "Freezing #{cookbook.name} at #{cookbook.version}..."
-              cookbook.freeze_version
-              Chef::CookbookUploader.new(cookbook, ::Chef::Config.cookbook_path).upload_cookbook
+          uploader = Chef::CookbookUploader.new(cookbook, ::Chef::Config.cookbook_path)
+          if name_args.include?(cookbook.name.to_s)
+            ui.info "Freezing #{cookbook.name} at #{cookbook.version}..."
+            cookbook.freeze_version
+            if uploader.respond_to?(:upload_cookbooks)
+              # Chef >= 10.14.0
+              uploader.upload_cookbooks
+            else
+              uploader.upload_cookbook
             end
           end
         rescue Net::HTTPServerException => e


### PR DESCRIPTION
Cleaner check for change in uploader API with Chef 10.14.x. Will support new Chef 10.14.2 rather than knife-spork 1.0.3 which would only support Chef 10.14.0
