### PR TITLE
show current time when promoting to remote

### DIFF
--- a/lib/chef/knife/spork-promote.rb
+++ b/lib/chef/knife/spork-promote.rb
@@ -45,7 +45,7 @@ module KnifeSpork
         if config[:remote]
           ui.msg "Uploading #{environment.name}.json to Chef Server"
           save_environment_changes_remote(e)
-          ui.info 'Promotion complete!'
+          ui.info "Promotion complete at #{Time.now}!"
         else
           ui.info "Promotion complete. Don't forget to upload your changed #{environment.name}.json to Chef Server"
         end


### PR DESCRIPTION
This shows a timestamp when promoting to remote. I often promote cookbooks and then check with `knife-lastrun` when a particular node or set of nodes runs chef next. But since I don't have the promotion time handy, I first have to find it in IRC again. Thought this might be helpful in general.
