### PR TITLE
patch to plugin enabled method supporting local overrides

### DIFF
--- a/lib/knife-spork/plugins/plugin.rb
+++ b/lib/knife-spork/plugins/plugin.rb
@@ -32,11 +32,7 @@ module KnifeSpork
       end
 
       def enabled?
-        if config.nil? || config.enabled == false
-            false
-        else
-            true
-        end
+        !(config.nil? || config.enabled == false)
       end
 
       private


### PR DESCRIPTION
The enabled? plugin method only returns false if a configuration stanza for a given plugin doesn't exist in the config. If you override the 'enabled' property in a local config this wasn't taken into account in the check.

Patch modifies enabled? to return false if the plugin config stanza doesn't exist or the enabled property for a plugin is set to false
