### PR TITLE
load cookbook after 'before_bump' handlers are run

### DIFF
--- a/lib/chef/knife/spork-bump.rb
+++ b/lib/chef/knife/spork-bump.rb
@@ -18,9 +18,8 @@ module KnifeSpork
         exit 1
       end
       
-      @cookbook = load_cookbook(name_args.first)
-
       run_plugins(:before_bump)
+      @cookbook = load_cookbook(name_args.first)
       bump
       run_plugins(:after_bump)
     end


### PR DESCRIPTION
before_bump pulls the remote repository. Since the cookbook is loaded before this is run, bump will still use the old version if metadata.rb has changed in the remote repo.

This change fixes it.
