### PR TITLE
Bugfix: List all remote cookbook versions when querying server side cookbooks.

### DIFF
--- a/lib/chef/knife/spork-upload.rb
+++ b/lib/chef/knife/spork-upload.rb
@@ -75,7 +75,7 @@ module KnifeSpork
               ui.info "Freezing #{cookbook.name} at #{cookbook.version}..."
               cookbook.freeze_version
               uploader.upload_cookbook
-              
+
             end
           end
         rescue Net::HTTPServerException => e
@@ -102,7 +102,7 @@ module KnifeSpork
     end
 
     def server_side_cookbooks(cookbook_name, version)
-      @server_side_cookbooks ||= Chef::CookbookVersion.list
+      @server_side_cookbooks ||= Chef::CookbookVersion.list_all_versions
 
       hash = @server_side_cookbooks[cookbook_name]
       hash && hash['versions'] && hash['versions'].any?{ |v| Chef::VersionConstraint.new(version).include?(v['version']) }


### PR DESCRIPTION
This fixes a bug that occurs if you're uploading a cookbook that depends on a specific version of a cookbook that would only be found on the remote chef server.

The current call you are using (list) only returns the newest version of the cookbook when checking dependencies on the remote server. The list_all_versions method will return all versions to allow a proper dependency check:

https://github.com/opscode/chef/blob/master/lib/chef/cookbook_version.rb#L636-643

This is the same method knife uses now when you do a stock "knife cookbook upload":

https://github.com/opscode/chef/blob/master/lib/chef/knife/cookbook_upload.rb#L93-95
