### PR TITLE
Use environment_path from spork config if it's set to save the new environment JSON file

### DIFF
--- a/lib/chef/knife/spork-promote.rb
+++ b/lib/chef/knife/spork-promote.rb
@@ -122,7 +122,7 @@ module KnifeSpork
     end
 
     def save_environment_changes(environment, json)
-      environments_path = cookbook_path.gsub('cookbooks', 'environments')
+      environments_path = spork_config[:environment_path] || cookbook_path.gsub('cookbooks', 'environments')
       environment_path = File.expand_path( File.join(environments_path, "#{environment}.json") )
 
       File.open(environment_path, 'w'){ |f| f.puts(json) }


### PR DESCRIPTION
Useful if you use Librarian with knife integration. Without this fix
it's not saving the file to your chef-repo, it's using the librarian
cache.
