### PR TITLE
Single Quotes for Version Number

### DIFF
--- a/lib/chef/knife/spork-bump.rb
+++ b/lib/chef/knife/spork-bump.rb
@@ -11,7 +11,7 @@ module KnifeSpork
 
     def run
       self.config = Chef::Config.merge!(config)
-      
+
       if @name_args.empty?
         show_usage
         ui.error("You must specify at least a cookbook name")
@@ -46,7 +46,7 @@ module KnifeSpork
       new_version = version_array.join('.')
 
       metadata_file = "#{@cookbook.root_dir}/metadata.rb"
-      new_contents = File.read(metadata_file).gsub(/version\s+['"][0-9\.]+['"]/, "version \"#{new_version}\"")
+      new_contents = File.read(metadata_file).gsub(/version\s+['"][0-9\.]+['"]/, "version '#{new_version}'")
       File.open(metadata_file, 'w'){ |f| f.write(new_contents) }
 
       ui.info "Successfully bumped #{@cookbook.name} to v#{new_version}!"


### PR DESCRIPTION
Per the Custom Ink food critic rules: [https://github.com/customink-webops/foodcritic-rules/blob/master/rules.rb](https://github.com/customink-webops/foodcritic-rules/blob/master/rules.rb)

`rule 'CINK002', 'Prefer single-quoted strings'...`

All I did was change the double quotes to single quotes in the bump command. Call it nit picky, but I think this and the Etsy rule set are gaining popularity, and it is a bummer to have to use spork bump and then go into the metadata file to change the quotes back.
