### PR TITLE
Support non-string cookbook_paths

### DIFF
--- a/lib/knife-spork/runner.rb
+++ b/lib/knife-spork/runner.rb
@@ -87,7 +87,7 @@ module KnifeSpork
       # always just use the first one in the path.
       def cookbook_path
         ensure_cookbook_path!
-        [config[:cookbook_path] ||= ::Chef::Config.cookbook_path].flatten[0]
+        [config[:cookbook_path] ||= ::Chef::Config.cookbook_path].flatten[0].to_s
       end
 
       def environment_path


### PR DESCRIPTION
Spork blows up if the first cookbook_path in knife.rb isn't a string:

```
runner.rb:17:in `spork_config': undefined method `gsub' for #<Pathname:0x00000002f90e28> (NoMethodError)
```

In my case the first cookbook_path is `Librarian::Chef.install_path()`.

This PR makes sure that the cookbook_path in spork is always a string.
