### PR TITLE
Add environment_groups option to config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-## 1.0.18 (18th June, 2013)
-
-Features:
-
-    - Add environment_groups option to YAML configuration. spork promote can update mulitiple environments at once by specifing the environment group name.
-
 ## 1.0.17 (15th February, 2013)
 
 Bugfixes:

--- a/knife-spork.gemspec
+++ b/knife-spork.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name          = 'knife-spork'
-  gem.version       = '1.0.18'
+  gem.version       = '1.0.17'
   gem.authors       = ["Jon Cowie"]
   gem.email         = 'jonlives@gmail.com'
   gem.homepage      = 'https://github.com/jonlives/knife-spork'


### PR DESCRIPTION
You can now add environment groups to the configuration file and running
spork promote group_name cookbook_name
will now update that cookbook on all environment groups included under
the specified environment group name in the configuration file.
