### PR TITLE
Corrected irccat color shortands.

### DIFF
--- a/lib/knife-spork/plugins/irccat.rb
+++ b/lib/knife-spork/plugins/irccat.rb
@@ -6,8 +6,8 @@ module KnifeSpork
       name :irccat
 
       TEMPLATES = {
-        :upload  => '#BOLD#PURPLECHEF:#NORMAL %{organization}%{current_user} uploaded #TEAL%{cookbooks}#NORMAL',
-        :promote => '#BOLD#PURPLECHEF:#NORMAL %{organization}%{current_user} promoted #TEAL%{cookbooks}#NORMAL to %{environment} %{gist}'
+        :upload  => '%%BOLD%%PURPLECHEF:%%NORMAL %{organization}%{current_user} uploaded %%TEAL%{cookbooks}%%NORMAL',
+        :promote => '%%BOLD%%PURPLECHEF:%%NORMAL %{organization}%{current_user} promoted %%TEAL%{cookbooks}%%NORMAL to %{environment} %{gist}'
       }
 
       def perform; end


### PR DESCRIPTION
Irccat changed their #COLOR shorthands to %COLOR, so this PR reflects this change on the irccat plugin.
