### PR TITLE
Lowercase MAJOR, MINOR, PATCH, MANUAL to reflect reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ This function lets you easily version your cookbooks without having to manually 
 
 #### Usage
 ```bash
-knife spork bump COOKBOOK [MAJOR | MINOR | PATCH | MANUAL x.x.x]
+knife spork bump COOKBOOK [major | minor | patch | manual x.x.x]
 ````
 
 #### Example (No patch level specified - defaulting to patch)


### PR DESCRIPTION
All-caps strings reflect something the user should substitute (as in: knife cookbook upload COOKBOOK). The proper options for bump are not to be used capitalized as indicated in this README, and do not stand for "replace this with your string", so should be lowercase.
