### PR TITLE
adding autobump feature to knife-spork check

### DIFF
--- a/lib/chef/knife/spork-check.rb
+++ b/lib/chef/knife/spork-check.rb
@@ -13,7 +13,7 @@ module KnifeSpork
       :description => 'Show all uploaded versions of the cookbook'
 
     option :autobump,
-      :short => '-b',
+      :short => '-p',
       :long => '--autobump',
       :description => 'If check shows a bump is needed, skip the prompt and bump'
       


### PR DESCRIPTION
This integration adds a new "-p/--autobump" option that will automatically bump the version if the knife spork check shows a bump is needed.

This is useful in CI applications

$ knife spork check $COOKBOOK --> given Y/N prompt prior to bumping
$ knife spork check $COOKBOOK -p --> No prompt, just a bump if needed
