### PR TITLE
Berkshelf fixes

### DIFF
--- a/lib/knife-spork/runner.rb
+++ b/lib/knife-spork/runner.rb
@@ -159,8 +159,13 @@ module KnifeSpork
           berksfile.resolve(lockfile.find(name), {skip_dependencies: self.config[:skip_dependencies]})[:solution].first
         }
 
-        #convert Berkshelf::CachedCookbook to Chef::CookbookVersion
-        ::Chef::CookbookLoader.new(File.dirname(cookbook.path))[name]
+        # convert Berkshelf::CachedCookbook to Chef::CookbookVersion by loading the cookback at the
+        # full path returned by Berkshelf (since a cookbook of name `x` is  not necessarily in a
+        # local directory named `x`.)
+        cookbook_path = cookbook.path
+        chef_search_dir = ::File.dirname(cookbook_path)
+        cookbook_dirname = ::File.basename(cookbook_path)
+        ::Chef::CookbookLoader.new(chef_search_dir).load_cookbook(cookbook_dirname)
 
       end
 

--- a/lib/knife-spork/runner.rb
+++ b/lib/knife-spork/runner.rb
@@ -6,6 +6,11 @@ require 'chef/cookbook_loader'
 require 'chef/knife/core/object_loader'
 require 'knife-spork/plugins'
 
+begin
+  require 'berkshelf'
+rescue LoadError
+end
+
 module KnifeSpork
   module Runner
     module ClassMethods; end


### PR DESCRIPTION
Resolve two issues I've run into trying to get knife-spork working with a one-repo-per-cookbook + berkshelf setup. In particular:
- Do a guarded import of `berkshelf`, which fixes an issue with `spork-bump.rb` not seeing `::Berkshelf`.
- Load berkshelf cookbooks from their full path as returned by Berkshelf, which resolves an issue with local cookbook directories not matching their name.

These changes have been tested on Berkshelf 2.x, but AFAICT they'd be necessary for Berkshelf 3.x support as well.
