### PR TITLE
HipChat plugin: Support custom server URL and API version

### DIFF
--- a/lib/knife-spork/plugins/hipchat.rb
+++ b/lib/knife-spork/plugins/hipchat.rb
@@ -102,7 +102,7 @@ module KnifeSpork
 
         rooms.each do |room_name|
           begin
-            client = ::HipChat::Client.new(config.api_token)
+            client = ::HipChat::Client.new(config.api_token, :api_version => config.api_version ||= 'v1', :server_url => config.server_url ||= 'https://api.hipchat.com')
             client[room_name].send(nickname, message, :notify => notify, :color =>color)
           rescue Exception => e
             ui.error 'Something went wrong sending to HipChat.'

--- a/plugins/HipChat.md
+++ b/plugins/HipChat.md
@@ -20,7 +20,9 @@ Configuration
 ```yaml
 plugins:
   hipchat:
+    server_url: https://api.hipchat.com
     api_token: ABC123
+    api_version: v1
     rooms:
       - General
       - Web Operations
@@ -28,8 +30,18 @@ plugins:
     color: yellow
 ```
 
+#### server_url
+The URL of the HipChat API server. Default: 'https://api.hipchat.com'
+
+- Type: `String`
+
 #### api_token
 Your HipChat API token.
+
+- Type: `String`
+
+#### api_version
+Which version of the HipChat API to use. Default: 'v1'
 
 - Type: `String`
 
@@ -44,7 +56,7 @@ Boolean value indicating whether the room should be notified.
 - Type: `Boolean`
 
 #### color
-THe color of the message.
+The color of the message.
 
 - Type: `String`
 - Acceptable Values: `[yellow, red, green, purple, random]`


### PR DESCRIPTION
This adds support for configuring a custom HipChat API server URL, and the ability to configure which HipChat API version to use.

This is needed to support the self-hosted version of HipChat (https://www.hipchat.com/server), where the HipChat service might run on https://hipchat.example.com for example.
