### PR TITLE
re-doing Bump_comment for version 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ role_path: "/home/me/roles"
 custom_plugin_path: "/home/me/spork-plugins"
 always_promote_remote: true
 skip_berkshelf: false
+bump_config: true
 json_options:
   indent: "    "
 plugins:
@@ -120,6 +121,9 @@ The `always_promote_remote` directive allows you to tell spork promote to always
 
 #### Skip Berkshelf
 The `skip_berkshelf` directive is a temporary flag added in [#138](https://github.com/jonlives/knife-spork/issues/138) to allow Berkshelf functionality to be optionally bypassed until Berkshelf 3 support has been added to knife-spork per [#85](https://github.com/jonlives/knife-spork/issues/85). It simply removed the :Berkshelf constant from the namespace used by knife-spork.
+
+#### Bump Comment
+The 'bump_comment` directive tells spork to always prompt the user for a comment reguarding the changes to this version of the cookbook. This comment will be appended to the CHANGELOG.md file along with the new version # and the user name.  This can also be done with the "--bump_comment" on the command line.
 
 #### JSON Options
 The `json_options` directive allows you to tell spork to pass options to [pretty_generate](http://www.ruby-doc.org/stdlib-1.9.3/libdoc/json/rdoc/JSON.html#method-i-pretty_generate) to control the format of the resulting json
@@ -236,17 +240,27 @@ Everything looks good!
 
 Spork Bump
 ----------
-This function lets you easily version your cookbooks without having to manually edit the cookbook's `metadata.rb` file. You can either specify the version level you'd like to bump (`major`, `minor`, or `patch`), or you can manually specify a version number. This might be used if, for example, you want to jump several version numbers in one go and don't want to have to run knife bump once for each number. If no bump level is specified, a patch level bump will be performed.
+This function lets you easily version your cookbooks without having to manually edit the cookbook's `metadata.rb` & `CHANGELOG.md` files. You can either specify the version level you'd like to bump (`major`, `minor`, or `patch`), or you can manually specify a version number. This might be used if, for example, you want to jump several version numbers in one go and don't want to have to run knife bump once for each number. If no bump level is specified, a patch level bump will be performed.
+
+Spork Bump can also be configured promt the user for a comment reguarding thier change.  This comment will be appended to the CHANGELOG.md file along with the new version, and the current username.  This is done either by using the '--bump_comment' option on the command line or by setting the bump_comment: directive to true.
 
 #### Usage
 ```bash
-knife spork bump COOKBOOK [major | minor | patch | manual x.x.x]
+knife spork bump COOKBOOK [major | minor | patch | manual x.x.x] [--bump_commment]
 ````
 
 #### Example (No patch level specified - defaulting to patch)
 ```text
-$ knife spork bump apache2
+$ knife spork bump apache2 --bump_comment
+Enter Change Log comment, then press Ctrl-D:
+"Bug #111 fixed."
 Successfully bumped apache2 to v2.0.4!
+```
+``` CHANGELOG.md will be appended with the following:
+
+2.0.4
+------
+<user> - Bug #111 fixed.
 ```
 
 #### Example (Bumping patch level)

--- a/lib/chef/knife/spork-bump.rb
+++ b/lib/chef/knife/spork-bump.rb
@@ -15,6 +15,11 @@ module KnifeSpork
            :description => 'A colon-separated path to look for cookbooks in',
            :proc => lambda { |o| o.split(':') }
 
+    option :bump_comment,
+           :long => '--bump_comment',
+           :description => 'Bump will prompt for a Change comment, which will be appended to CHANGELOG.md along with the new version # and username',
+           :default => nil
+
     if defined?(::Berkshelf)
       option :berksfile,
         :short => '-b',
@@ -29,12 +34,13 @@ module KnifeSpork
         :default => true
     end
 
-    banner 'knife spork bump COOKBOOK [major|minor|patch|manual]'
+    banner 'knife spork bump COOKBOOK [major|minor|patch|manual] [--bump_comment]'
 
     def run
       self.class.send(:include, KnifeSpork::Runner)
       self.config = Chef::Config.merge!(config)
       config[:cookbook_path] ||= Chef::Config[:cookbook_path]
+      config[:bump_comment] ||= spork_config.bump_comment
 
       if @name_args.empty?
         show_usage
@@ -77,6 +83,17 @@ module KnifeSpork
       metadata_file = "#{@cookbook.root_dir}/metadata.rb"
       new_contents = File.read(metadata_file).gsub(/(version\s+['"])[0-9\.]+(['"])/, "\\1#{new_version}\\2")
       File.open(metadata_file, 'w'){ |f| f.write(new_contents) }
+
+      if config[:bump_comment]
+        changelog_file =  "#{@cookbook.root_dir}/CHANGELOG.md"
+        ui.info "Enter Change Log comment, then press Ctrl-D:  "
+        change_comment = $stdin.read
+        File.open(changelog_file, 'a') { |cl|
+          cl.write("\n#{new_version}\n")
+          cl.write("---------\n")
+          cl.write("#{ENV['USER']} - #{change_comment}\n")
+        }
+      end
 
       ui.info "Successfully bumped #{@cookbook.name} to v#{new_version}!"
     end

--- a/lib/knife-spork/plugins/git.rb
+++ b/lib/knife-spork/plugins/git.rb
@@ -37,6 +37,7 @@ module KnifeSpork
       def after_bump
         cookbooks.each do |cookbook|
           git_add(cookbook_path_for(cookbook),"metadata.rb")
+          git_add(cookbook_path_for(cookbook),"CHANGELOG.md")
         end
       end
 

--- a/lib/knife-spork/runner.rb
+++ b/lib/knife-spork/runner.rb
@@ -158,6 +158,10 @@ module KnifeSpork
         ::Chef::CookbookLoader.new(::Chef::Config.cookbook_path)
       end
 
+      def bump_comment
+        spork_config[:bump_comment] || false
+      end
+
       def load_cookbook(name)
         return name if name.is_a?(Chef::CookbookVersion)
 


### PR DESCRIPTION
I was a noob and royally hosed my fork when trying to bring it in line with 1.4.  So, I blew it away and started over.  As such, I've closed pull request #123 and I'm re-submitting this (hopefully clean) one.

This adds an option to the spork bump plug-in to prompt the user for a comment about their change (the reason for the bump). This comment is appended to CHANGELOG.md in the following format:

<new_version>
--------
<user> - <comment>

The Git plugin was also updated to 'git add CHANGELOG.md' during ":after_bump"

Future ideas/ possible refinements:
  - Pass comment to a git commit.
  - Pass comment to various communications plugins (we don't currently use any of these, so may need help here).
  - Pull windows username as well as UNIX "ENV['USER']"