### PR TITLE
add support for rubocop >= 0.23.0

### DIFF
--- a/lib/knife-spork/plugins/rubocop.rb
+++ b/lib/knife-spork/plugins/rubocop.rb
@@ -32,7 +32,7 @@ module KnifeSpork
 
           options = [ cookbook_path ]
 
-          cli = ::Rubocop::CLI.new
+          cli = defined?(RuboCop) ? ::RuboCop::CLI.new : ::Rubocop::CLI.new
           result = cli.run(options)
 
           unless result  == 0


### PR DESCRIPTION
in 0.23.0 they renamed `Rubocop` module to `RuboCop`
