### PR TITLE
pass whole config, not just cookbook_path

### DIFF
--- a/lib/chef/knife/spork-upload.rb
+++ b/lib/chef/knife/spork-upload.rb
@@ -84,7 +84,7 @@ module KnifeSpork
         begin
           check_dependencies(cookbook)
           if name_args.include?(cookbook.name.to_s)
-            if Gem::Version.new(Chef::VERSION) > Gem::Version.new('12.0.0')
+            if Gem::Version.new(Chef::VERSION).release >= Gem::Version.new('12.0.0')
               uploader = Chef::CookbookUploader.new(cookbook)
             else
               uploader = Chef::CookbookUploader.new(cookbook, ::Chef::Config.cookbook_path)


### PR DESCRIPTION
This was causing an issue (#140) because we were passing an Array instead of a Hash, and CookbookUploader no longer accepts a `path` argument.

Compare the two following links:

https://github.com/opscode/chef/blob/11.14.6/lib/chef/cookbook_uploader.rb#L39
https://github.com/opscode/chef/blob/12.0.0.alpha.1/lib/chef/cookbook_uploader.rb#L38
