### PR TITLE
Fix for when custom_path is not defined.  on Windows this was causing th...

### DIFF
--- a/lib/knife-spork/plugins.rb
+++ b/lib/knife-spork/plugins.rb
@@ -7,7 +7,9 @@ module KnifeSpork
       hook = options[:hook].to_sym
 
       #Load each of the drop-in plugins specified in the custom plugin path
-      Dir[File.expand_path("#{options[:config][:custom_plugin_path]}/*.rb")].each { |f| require f }
+      if (options[:config][:custom_plugin_path] !=nil)
+        Dir[File.expand_path("#{options[:config][:custom_plugin_path]}/*.rb")].each { |f| require f }
+      end
 
       klasses.each do |klass|
         plugin = klass.new(options)


### PR DESCRIPTION
...e cookbook to not be bumped correctly, and was failing without an exception

Sample output pre change:
C:\code\Internal\cookbooks\eis\sys_win_base>knife spork bump sys_win_base -o "./../"
exit
I ran

Post Change:
C:\code\Internal\cookbooks\eis\sys_win_base>knife spork bump sys_win_base -o "./../"
Successfully bumped sys_win_base to v0.2.5!
