### PR TITLE
Better error messages when uploading syntactically incorrect json

### DIFF
--- a/lib/knife-spork/runner.rb
+++ b/lib/knife-spork/runner.rb
@@ -231,7 +231,7 @@ module KnifeSpork
         begin
           environment_loader.object_from_file("#{environment_path}/#{environment_name}.json")
         rescue Yajl::ParseError => e
-          raise "#{environment_name} has syntactically incorrect json: #{e.to_s}" 
+          raise "#{environment_name} environment file has syntactically incorrect json.\n #{e.to_s}" 
         end
       end
 


### PR DESCRIPTION
When I omnied a cookbook, I was confused when I saw the following error message: 

``` bash
ERROR: Yajl::ParseError: parse error: invalid object key (must be a string)
          asdasdasdad"     },   } }
                     (right here) ------^
```

Turns out the environment had syntactically incorrect json. Also, Tte error message should be more clear in conveying what environment file is affected.

This patch shows an improved error message specifying the affected environment file: 

``` bash
ERROR: RuntimeError: Environment environment file has syntactically incorrect json: 
parse error: invalid object key (must be a string)
          asdasdasdasdasd"     },   } }
                     (right here) ------^
```
