### PR TITLE
rolefromfile: ensuring file name matches name provided in file

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ role_path: "/home/me/roles"
 custom_plugin_path: "/home/me/spork-plugins"
 always_promote_remote: true
 skip_berkshelf: false
+role_match_file_name: true
 json_options:
   indent: "    "
 plugins:
@@ -133,6 +134,9 @@ The `environment_path` allows you to specify the path to where you store your ch
 
 #### Role Path
 The `role_path` allows you to specify the path to where you store your chef role json files. If this parameter is not specified, spork will default to using the first element of your cookbook_path, replacing the word "cookbooks" with "roles"
+
+#### Role Match File Name
+The `role_match_file_name` flag allows you to check whether the file name that is used to upload a role matches the role name as well. If the parameter is specified, or flag `--match-filename` is set, spork will not let you upload a role from a file unless the name matches the rolename.
 
 #### Custom Plugin Path
 The `custom_plugin_path` allows you to specify an additional directory from which to load knife-spork plugins. If this parameter is not specified or the path set does not exist, only the default plugins shipped with knife-spork will be loaded (if enabled in config)

--- a/lib/chef/knife/spork-role-fromfile.rb
+++ b/lib/chef/knife/spork-role-fromfile.rb
@@ -11,6 +11,13 @@ module KnifeSpork
 
     banner 'knife spork role from file FILENAME (options)'
 
+    option :match_filename,
+        :long => '--match-filename',
+        :short => '-f',
+        :description => 'Ensure that the filename matches the name specified in the role (true|false).',
+        :boolean => true,
+        :default => false
+
     def run
       self.class.send(:include, KnifeSpork::Runner)
       self.config = Chef::Config.merge!(config)
@@ -40,15 +47,17 @@ module KnifeSpork
     def role_from_file
       rff = Chef::Knife::RoleFromFile.new
       rff.name_args = @name_args
-      ## Check if file names match role names 
-      @name_args.each do |arg|
-          file_name = arg.split("/").last
-          role = rff.loader.load_from("roles", file_name)
-          file_name = file_name.gsub(".json","").gsub(".rb", "")
-          if file_name != role.name
-              ui.error("Role name in file #{role.name} does not match file name #{file_name}")
-              exit 1
-          end
+      if (config[:match_filename] || spork_config[:role_match_file_name])
+        ## Check if file names match role names 
+        @name_args.each do |arg|
+            file_name = arg.split("/").last
+            role = rff.loader.load_from("roles", file_name)
+            file_name = file_name.gsub(".json","").gsub(".rb", "")
+            if file_name != role.name
+                ui.error("Role name in file #{role.name} does not match file name #{file_name}")
+                exit 1
+            end
+        end
       end
       rff.run
     end

--- a/lib/chef/knife/spork-role-fromfile.rb
+++ b/lib/chef/knife/spork-role-fromfile.rb
@@ -40,6 +40,16 @@ module KnifeSpork
     def role_from_file
       rff = Chef::Knife::RoleFromFile.new
       rff.name_args = @name_args
+      ## Check if file names match role names 
+      @name_args.each do |arg|
+          file_name = arg.split("/").last
+          role = rff.loader.load_from("roles", file_name)
+          file_name = file_name.gsub(".json","").gsub(".rb", "")
+          if file_name != role.name
+              ui.error("Role name in file #{role.name} does not match file name #{file_name}")
+              exit 1
+          end
+      end
       rff.run
     end
   end


### PR DESCRIPTION
Currently, the spork role from file plugin does not check whether the file name matches the name provided inside role file. Adding a check to ensure these match up before we upload the role.