### PR TITLE
change from Yajl to FFI_Yajl

### DIFF
--- a/lib/knife-spork/runner.rb
+++ b/lib/knife-spork/runner.rb
@@ -231,7 +231,7 @@ module KnifeSpork
       def load_environment_from_file(environment_name)
         begin
           environment_loader.object_from_file("#{environment_path}/#{environment_name}.json")
-        rescue Yajl::ParseError => e
+        rescue FFI_Yajl::ParseError => e
           raise "#{environment_name} environment file has syntactically incorrect json.\n #{e.to_s}" 
         end
       end


### PR DESCRIPTION
Looks like the class of the exception changed in the latest version: 

```bash
ERROR: FFI_Yajl::ParseError: parse error: after key and value, inside map, I expect ',' or '}'
          chef_type": "environment"   "default_attributes": {   },   "
                               (right here) ------^
```

Changed the class of the exception. 