### PR TITLE
Fixing broken slack support.

### DIFF
--- a/lib/knife-spork/plugins/slack.rb
+++ b/lib/knife-spork/plugins/slack.rb
@@ -100,7 +100,7 @@ module KnifeSpork
       def slack(message)
         safe_require 'slack-notifier'
         begin
-          notifier = ::Slack::Notifier.new( config.teamname, config.api_token, channel: channel, username: username, icon_url: config.icon_url)
+          notifier = ::Slack::Notifier.new( config.webhook_url, channel: channel, username: username, icon_url: config.icon_url)
           notifier.ping message 
         rescue Exception => e
           ui.error 'Something went wrong sending to Slack.'

--- a/plugins/Slack.md
+++ b/plugins/Slack.md
@@ -20,14 +20,14 @@ Configuration
 ```yaml
 plugins:
   slack:
-    api_token: ABC123
+    webhook_url: https://hooks.slack.com/services/AABBCC
     channel: "#operations"
     teamname: myteam
     username: knife
 ```
 
 #### api_token
-Your Slack API token.
+Your Slack Webhook URL.
 
 - Type: `String`
 
@@ -36,10 +36,6 @@ The channel to post to.
 
 - Type: `String`
 
-#### teamname
-The teamname of the slack account. ex. https://TEAMNAME.slack.com
-
-- Type: `String`
 
 #### username
 The username to post as.


### PR DESCRIPTION
The following commit adapts the arguments to the
method call .new to the newest format specified by 
the underlying slack-notifier gem used by this to
provide slack support.

Documentation is edited accordingly.