### PR TITLE
add missing yajl require

### DIFF
--- a/lib/knife-spork/runner.rb
+++ b/lib/knife-spork/runner.rb
@@ -1,6 +1,7 @@
 require 'app_conf'
 require 'diffy'
 require 'json'
+require 'yajl'
 
 require 'chef/cookbook_loader'
 require 'chef/knife/core/object_loader'


### PR DESCRIPTION
If there was a problem with the environment file (i.e. missing) you got an error like this instead of the real error:

```uninitialized constant KnifeSpork::Runner::InstanceMethods::Yajl```