### PR TITLE
fix knife spork omni with skip_berkshelf: true

### DIFF
--- a/lib/knife-spork/runner.rb
+++ b/lib/knife-spork/runner.rb
@@ -300,7 +300,7 @@ module KnifeSpork
         # to be bypassed until #85 has been completed and Berkshelf 3 support added
         if spork_config.skip_berkshelf
           ui.warn "Unloading Berkshelf as skip_berkshelf option found in config"
-          Object.send(:remove_const, :Berkshelf)
+          Object.send(:remove_const, :Berkshelf) if defined?(::Berkshelf)
         end
       end
     end


### PR DESCRIPTION
PROBLEM: 
```ruby 
/.rvm/gems/ruby-2.0.0-p247/gems/knife-spork-1.4.1/lib/knife-spork/runner.rb:300:in `remove_const': constant Object::Berkshelf not defined (NameError)
	from /Users/me/.rvm/gems/ruby-2.0.0-p247/gems/knife-spork-1.4.1/lib/knife-spork/runner.rb:300:in `unload_berkshelf_if_specified'
	from /Users/me/.rvm/gems/ruby-2.0.0-p247/gems/knife-spork-1.4.1/lib/chef/knife/spork-omni.rb:63:in `run'
	from /Users/me/.rvm/gems/ruby-2.0.0-p247/gems/chef-11.16.2/lib/chef/knife.rb:493:in `run_with_pretty_exceptions'
	from /Users/me/.rvm/gems/ruby-2.0.0-p247/gems/chef-11.16.2/lib/chef/knife.rb:174:in `run'
	from /Users/me/.rvm/gems/ruby-2.0.0-p247/gems/chef-11.16.2/lib/chef/application/knife.rb:139:in `run'
	from /Users/me/.rvm/gems/ruby-2.0.0-p247/gems/chef-11.16.2/bin/knife:25:in `<top (required)>'
	from /Users/me/.rvm/gems/ruby-2.0.0-p247/bin/knife:23:in `load'
	from /Users/me/.rvm/gems/ruby-2.0.0-p247/bin/knife:23:in `<main>'
	from /Users/me/.rvm/gems/ruby-2.0.0-p247/bin/ruby_executable_hooks:15:in `eval'
	from /Users/me/.rvm/gems/ruby-2.0.0-p247/bin/ruby_executable_hooks:15:in `<main>'
```

if Object::Berkshelf is not defined we can't remove this const.