### PR TITLE
Add --cookbook-path to the promote subcommand

### DIFF
--- a/lib/chef/knife/spork-promote.rb
+++ b/lib/chef/knife/spork-promote.rb
@@ -24,6 +24,12 @@ module KnifeSpork
       :description => 'Save the environment to the chef server in addition to the local JSON file',
       :default => nil
 
+    option :cookbook_path,
+         :short => '-o PATH:PATH',
+         :long => '--cookbook-path PATH:PATH',
+         :description => 'A colon-separated path to look for cookbooks in',
+         :proc => lambda { |o| o.split(':') }
+
     if defined?(::Berkshelf)
       option :berksfile,
         :short => '-b',


### PR DESCRIPTION
Unlike other Spork subcommands, `--cookbook-path` is not supported by `spork promote`.

This option is apparently needed when running all Spork subcommands in a repo-per-cookbook setup (this might fix #85). For example, when an `example` cookbook sits in the folder

    ~/dev/
      example/
        cookbooks/
          example/
            ···
            metadata.rb
            Berksfile
            Berskfile.lock
            ···

regardless of the value used for `skip_berkshelf` the operation fails. With `skip_berkshelf = false`:

    user@box:~/dev$ knife spork promote production example
    ERROR: Berkshelf::BerksfileReadError: Berkshelf::BerksfileReadError
    
    user@box:~/dev$ knife spork promote production example -b example/cookbooks/example/Berksfile
    ERROR: Berkshelf::BerkshelfError: LockFileNotFound
    
    user@box:~/dev$ knife spork promote production example -b example/cookbooks/example/Berksfile.lock
    ERROR: SyntaxError: /home/user/dev/example/cookbooks/example/Berksfile.lock:3: syntax error, unexpected ':', expecting end-of-input
        path: .

With `skip_berkshelf = true`:

    user@box:~/dev/example$ knife spork promote production example
    WARNING: Unloading Berkshelf as skip_berkshelf option found in config
    ERROR: Chef::Exceptions::CookbookNotFound: Could not find cookbook 'example' in any of the sources!

Although this seems to point to problems with Berkshelf 3, specifying the cookbook path actually works
(even with `skip_berkshelf = false`):

    user@box:~/dev$ knife spork promote production example -o example/cookbooks
    Adding version constraint example = 0.1.1
    Saving changes to production.json
    Uploading production.json to Chef Server
    Promotion complete at 2015-01-12 15:12:58 +0000!