### PR TITLE
Added troubleshooting section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,3 +502,13 @@ knife spork environment delete
 knife spork environment edit
 knife spork environment from file
 ```
+
+Troubleshooting
+---------------
+If you get an error when running `knife spork <command>` and the message shown when running with the `-VV` flag contains:
+```ruby
+undefined method `gsub' for #<Pathname:0x00000002d3a6b0> (NoMethodError)
+```
+...then you are probably using `Librarian::Chef.install_path()` in your `knife.rb` file.
+
+To fix this you need to call `.to_s` on the install path, i.e. ``Librarian::Chef.install_path().to_s`.


### PR DESCRIPTION
I fell foul of this when first setting up spork so it'd be nice to have it documented. Found the fix in #69 and added it to the readme.

The section is at the bottom of the file but perhaps it should be closer to the top?