### PR TITLE
have promote check for latest cookbook

### DIFF
--- a/lib/chef/knife/spork-promote.rb
+++ b/lib/chef/knife/spork-promote.rb
@@ -61,6 +61,7 @@ module KnifeSpork
       @environments, @cookbook = load_environments_and_cookbook
 
       check_cookbook_uploaded(@cookbook)
+      check_cookbook_latest(@cookbook)
 
       @environments.each do |e|
         environment = load_environment_from_file(e)
@@ -180,6 +181,16 @@ module KnifeSpork
       rescue Net::HTTPServerException => e
         ui.error "#{cookbook_name}@#{version} does not exist on Chef Server! Upload the cookbook first by running:\n\n\tknife spork upload #{cookbook_name}\n\n"
         exit(1)
+      end
+    end
+
+    def check_cookbook_latest(cookbook_name)
+      validate_version!(config[:version])
+      version = config[:version] || load_cookbook(cookbook_name).version
+      cb_latest = Chef::CookbookVersion.load(cookbook_name).metadata.version
+      # ui.msg "server: #{cb_latest} -- local: #{version}"
+      if cb_latest > version
+        ui.confirm "Ther is a later verison of #{cookbook_name} on the chef server.  Continue?"
       end
     end
   end


### PR DESCRIPTION
This change adds a check to spork-promote which warns if the cookbook version being promoted is not the latest available on the chef server.

We have run into situations where the person promoting the cookbook had not updated their cookbook repo and therefore had an older version of the cookbook than intended.

currently, is simply asks if you want to continue (similar to the version threshold warning), but I was thinking of giving the option to use the version on the server instead.  Figured I would throw this out there and see what you thought first.