### PR TITLE
Accepting higher versions from remote on promote remote

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,8 @@ task :preseed_test_environment do
   @server.start_background
   puts "Uploading test data"
   system("knife cookbook upload example -c spec/unit/fixtures/knife.rb")
-  system("knife environment from file spec/unit/fixtures/environments/example.json -c spec/unit/fixtures/knife.rb")
+  # example-remote is the state we want the chef server to be in
+  system("knife environment from file spec/unit/fixtures/environments/example-remote.json -c spec/unit/fixtures/knife.rb")
 end
 
 task :cleanup_test_environment do
@@ -33,3 +34,4 @@ task :cleanup_test_environment do
 end
 
 task :default => [:preseed_test_environment, :test, :cleanup_test_environment]
+

--- a/spec/unit/fixtures/environments/example-remote.json
+++ b/spec/unit/fixtures/environments/example-remote.json
@@ -2,7 +2,7 @@
   "name": "example",
   "description": "This is an example environment",
   "cookbook_versions": {
-    "example2" : "= 0.0.1"
+    "example2": "= 0.0.2"
   },
   "json_class": "Chef::Environment",
   "chef_type": "environment",

--- a/spec/unit/spork_promote_spec.rb
+++ b/spec/unit/spork_promote_spec.rb
@@ -71,7 +71,9 @@ module KnifeSpork
         knife.instance_variable_set(:@environments, ["example"])
         knife.instance_variable_set(:@cookbook, "example")
         knife.send(:save_environment_changes_remote, "example")
+        File.read(environment_file).should include "\"example2\": \"= 0.0.2\""
       end
     end
+
   end
 end


### PR DESCRIPTION
Proposal: 
A knife spork promote remote currently downloads the remote environment, compares it with the local environment, and unless things fail, uploads the entire local environment. This proposal is to change this behavior to accept versions of cookbooks higher than local from remote, and edit the local file to reflect that. So, at the end of the promote --remote act, all data will be reflect the *highest* version of the set of versions under consideration.

This change will not make the race condition that currently exists better or worse since this is determined by when remote gets downloaded against when it’s uploaded. The race condition can be encountered in the following scenario:
A runs promote —remote
B runs promote —remote
A downloads remote environment
B downloads remote environment
B uploads local environment, bumping a cookbook, e.g. apache to 2
A uploads local environment, bumping a cookbook, e.g. php to 2, this will downgrade apache to 1.
