### PR TITLE
Warn about incorrect data bag from file usage

### DIFF
--- a/lib/chef/knife/spork-databag-fromfile.rb
+++ b/lib/chef/knife/spork-databag-fromfile.rb
@@ -30,6 +30,12 @@ module KnifeSpork
       self.config = Chef::Config.merge!(config)
 
       @object_name = @name_args.first
+      # This should be the data bag name. If it isn't, some poor soul forgot the data bag name.
+      # Check to see if there are any more arguments, and if not, warn about usage.
+      if @name_args.drop(1).size == 0
+        print "USAGE: #{banner}"
+        exit(1)
+      end
 
       if config[:all] == true
         test = Chef::Knife::DataBagFromFile.new


### PR DESCRIPTION
Because it's confusing when you get the arguments wrong and you get no error message and a 0 exit code and then wonder why your change didn't work.