### PR TITLE
Added plugin to update CHANGELOG.md on bump

### DIFF
--- a/lib/knife-spork/plugins/changelog.rb
+++ b/lib/knife-spork/plugins/changelog.rb
@@ -1,0 +1,67 @@
+require 'knife-spork/plugins/plugin'
+
+module KnifeSpork
+  module Plugins
+    class Changelog < Plugin
+      name :changelog
+
+      def perform; end
+
+      def after_bump
+        cookbooks.each do |cookbook|
+          changelog_file = "#{cookbook_path_for(cookbook)}/CHANGELOG.md"
+          metadata_file = "#{cookbook_path_for(cookbook)}/metadata.rb"
+
+          # Read the current CHANGELOG.md contents into an Array
+          f = File.open(changelog_file, 'r+')
+          lines = f.readlines
+          f.close
+
+          # Pull the new version from the metadata.rb file on disk (this is not yet updated in the CookbookVersion object)
+          version_line = File.open(metadata_file, 'r').readlines.select { |line| line.start_with?('version') }
+          version_line = version_line[0]
+          version = version_line.match(/[0-9\.]+/)[0]
+
+          # Compose the CHANGELOG entry, preserving header lines if configured
+          new_lines = []
+          if preserve_lines > 0
+            new_lines = lines[0..(preserve_lines-1)] 
+          end
+          new_lines = new_lines + changelog_entry_for(version)
+          new_lines = new_lines + lines[preserve_lines..-1]
+
+          # Write the new CHANGELOG.md file
+          output = File.new(changelog_file, 'w')
+          output.puts new_lines
+          output.close
+          ui.info "CHANGELOG.md for cookbook #{cookbook.name} successfully updated"
+        end
+      end
+
+      def preserve_lines
+        config.preserve_lines || 0
+      end
+
+      def default_comment
+        config.default_comment || "Bump"
+      end
+
+      def changelog_entry_for version
+        entry = [version]
+        entry << '-' * version.length
+        entry << "- [#{current_user}] #{default_comment}"
+        entry << ''
+        entry
+      end
+
+      def cookbook_path_for cookbook
+        if defined?(Berkshelf) and cookbook.is_a? Berkshelf::CachedCookbook
+          cookbook.path.to_s
+        else
+          cookbook.root_dir
+        end
+      end
+
+    end
+  end
+end

--- a/plugins/Changelog.md
+++ b/plugins/Changelog.md
@@ -1,0 +1,40 @@
+Changelog
+=========
+This plugin attempts to help manage your workflow by automatically adding a templated entry to the CHANGELOG.md file when performing a bump action.
+
+Gem Requirements
+----------------
+This plugin has no gem requirements.
+
+Hooks
+-----
+- `after_bump`
+
+Configuration
+-------------
+```yaml
+plugins:
+  changelog:
+    preserve_lines: 5
+    default_comment: "Version bump, no functional changes"
+```
+
+**Note** You may choose to accept all the defaults. In that case, you should make your configuration like this:
+
+```yaml
+plugins:
+  changelog:
+    enabled: true
+```
+
+#### preserve_lines
+A number of lines to be preserved at the head of the CHANGELOG.md file. Use if your standard CHANGELOG.md format includes a header section which you would like to remain at the top of the file.
+
+- Type: `Integer`
+- Default: `0`
+
+#### default_comment
+The comment added to the CHANGELOG.md file along with the author's username and the new version number.
+
+- Type: `String`
+- Default: `Bump`


### PR DESCRIPTION
Our team would like to ensure the CHANGELOG.md is kept in sync with version bumps applied to metadata.rb, and since we often (for various reasons) need to bump a version with no other meaningful changes, I wrote this simple plugin to do just that. We can use it through the custom plugin mechanism but thought I would submit it for general consideration.