### PR TITLE
Check the correct value for epic fail

### DIFF
--- a/lib/knife-spork/plugins/foodcritic.rb
+++ b/lib/knife-spork/plugins/foodcritic.rb
@@ -31,7 +31,7 @@ module KnifeSpork
           if review.failed?
             ui.error "Foodcritic failed!"
             review.to_s.split("\n").each{ |r| ui.error r.to_s }
-            exit(1) if config.epic_fail
+            exit(1) if epic_fail?
           else
             ui.info "Passed!"
           end


### PR DESCRIPTION
Previously this was directly checking the config value 'epic_fail' which misses
taking advantage of the epic_fail? wrapper function that'll deal with the
missing value correctly