### PR TITLE
Cater for roles in subdirs when checking filename against role name

### DIFF
--- a/lib/chef/knife/spork-role-fromfile.rb
+++ b/lib/chef/knife/spork-role-fromfile.rb
@@ -50,10 +50,10 @@ module KnifeSpork
       if (config[:match_filename] || spork_config[:role_match_file_name])
         ## Check if file names match role names 
         @name_args.each do |arg|
+            role = rff.loader.load_from("roles", arg)
             file_name = arg.split("/").last
-            role = rff.loader.load_from("roles", file_name)
-            file_name = file_name.gsub(".json","").gsub(".rb", "")
-            if file_name != role.name
+            role_name = file_name.gsub(".json","").gsub(".rb", "")
+            if role_name != role.name
                 ui.error("Role name in file #{role.name} does not match file name #{file_name}")
                 exit 1
             end

--- a/lib/knife-spork/plugins/foodcritic.rb
+++ b/lib/knife-spork/plugins/foodcritic.rb
@@ -31,7 +31,7 @@ module KnifeSpork
           if review.failed?
             ui.error "Foodcritic failed!"
             review.to_s.split("\n").each{ |r| ui.error r.to_s }
-            exit(1) if config.epic_fail
+            exit(1) if epic_fail?
           else
             ui.info "Passed!"
           end


### PR DESCRIPTION
Previously, the path components were removed before loading the role file when checking the rolename inside the role. This would break if your role file were in a subdirectory of the roles dir

The fix is to use the whole of the arg variable as the path to the role file