### PR TITLE
Adding a wrapper for cookbook deletion command and options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
 rvm:
-  - 2.1.1
+  - 2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
+## 1.6.3(12th December, 2016)
+
+Features:
+
+    - Added commands to delete cookbooks (Thanks to kdaniels https://github.com/jonlives/knife-spork/pull/205)
+
+
 ## 1.6.2(13th June, 2016)
 
 Features:
 
-    - Search for spork config file in .chef directory under current working dir (Thansk to jgoulah https://github.com/jonlives/knife-spork/pull/203)
+    - Search for spork config file in .chef directory under current working dir (Thanks to jgoulah https://github.com/jonlives/knife-spork/pull/203)
 
 Bugfixes:
 

--- a/README.md
+++ b/README.md
@@ -337,6 +337,24 @@ Saving changes to my_environment.json
 Promotion complete. Don't forget to upload your changed my_environment to Chef Server
 ```
 
+Spork Delete
+------------
+This function works mostly the same as normal `knife cookbook delete COOKBOOK` including options to delete all versions and delete without interactive confirmation.
+
+#### Usage
+```bash
+knife spork delete COOKBOOK
+```
+#### Example
+```text
+$ knife spork delete apache2 -a
+WARNING: Deleting cookbook apache2...
+Do you really want to delete all versions of apache2? (Y/N) Y
+Deleted cookbook[apache2][2.0.2]
+Successfully deleted cookbook apache2 ALL versions from the Chef server
+Cookbooks deleted from Chef server: apache2: ALL versions
+```
+
 Spork Omni
 -------------
 Omni lets you combine one of the most common combinations of spork commands (bump, upload & promote or promote --remote) - into one handy shortcut.

--- a/lib/chef/knife/spork-delete.rb
+++ b/lib/chef/knife/spork-delete.rb
@@ -1,0 +1,132 @@
+require 'chef/knife'
+
+module KnifeSpork
+  class SporkDelete < Chef::Knife
+    deps do
+      require 'chef/exceptions'
+      require 'knife-spork/runner'
+      require 'socket'
+    end
+
+    ALL_NO_CONF = 'all_no_conf'.freeze
+    ALL_CONF = 'all_conf'.freeze
+    ONE_NO_CONF = 'one_no_conf'.freeze
+    ONE_CONF = 'one_conf'.freeze
+
+    banner 'knife spork delete [COOKBOOKS...] (options)'
+
+    option :cookbook_path,
+      :short => '-o PATH:PATH',
+      :long => '--cookbook-path PATH:PATH',
+      :description => 'A colon-separated path to look for cookbooks in',
+      :proc => lambda { |o| o.split(':') }
+
+    option :yes,
+      :short => '-y',
+      :long => '--yes',
+      :description => 'Say yes to all prompts for confirmation'
+
+    option :all,
+      :short => '-a',
+      :long => '--all',
+      :description => 'Delete all versions of the specified cookbooks'
+
+
+    def run
+      self.class.send(:include, KnifeSpork::Runner)
+      self.config = Chef::Config.merge!(config)
+      config[:cookbook_path] ||= Chef::Config[:cookbook_path]
+
+      if @name_args.empty?
+        show_usage
+        ui.error("You must specify the --all flag or at least one cookbook name")
+        exit 1
+      end
+
+      delete
+      @misc_output = @deleted_cookbook_string
+      run_plugins(:after_delete)
+    end
+
+    private
+
+    def printable_version_string(version)
+      # The version variable might be a string or an array. The array might even be empty.
+      # Based on what it is, we will return a string that says something like "versions 1, 2" or "version 1" or "ALL versions"
+      # for more human-readable output.
+      if (version.class == Array and version.size == 0) or version == "ALL"
+        return "ALL versions"
+      elsif version.class == Array
+        if version.size > 1
+          return "versions #{version.join(', ')}"
+        else
+          return "version #{version.join(', ')}"
+        end
+      else
+        return "version #{version}"
+      end
+    end 
+
+    def run_knife_command(cookbook_name, command, version = [])
+      begin
+        ui.warn("Deleting cookbook #{cookbook_name}...")
+        case command
+        when ALL_NO_CONF
+          @knife.delete_all_without_confirmation
+        when ALL_CONF
+          @knife.delete_all_versions
+        when ONE_NO_CONF
+          @knife.delete_versions_without_confirmation(version)
+        when ONE_CONF
+          @knife.version = version
+          @knife.delete_explicit_version
+        end
+        ui.msg("Successfully deleted cookbook #{cookbook_name} #{printable_version_string(version)} from the Chef server")
+        true
+      rescue SystemExit
+        # The user said no at a confirmation prompt, just continue. But return false since we
+        # didn't actually delete anything.
+        false
+      rescue Exception => e
+        ui.error("Error deleting cookbook #{cookbook_name}: #{e}")
+        false
+      end
+    end
+
+    def delete
+      @deleted_cookbooks = []
+      name_args.each do |cookbook_name|
+        @knife = Chef::Knife::CookbookDelete.new
+        @knife.name_args = cookbook_name
+        @knife.cookbook_name = cookbook_name
+        if config[:all]
+          @knife.config[:all] = true
+          if config[:yes]
+            @deleted_cookbooks.push([cookbook_name, "ALL"]) if run_knife_command(cookbook_name, ALL_NO_CONF)
+          else
+            @deleted_cookbooks.push([cookbook_name, "ALL"]) if run_knife_command(cookbook_name, ALL_CONF)
+          end
+        else
+          begin
+            versions_to_delete = @knife.ask_which_versions_to_delete
+          rescue NoMethodError
+            # Rescuing this means the output from knife itself already gets printed, no need to duplicate that.
+            exit 1
+          end
+          if config[:yes]
+            @deleted_cookbooks.push([cookbook_name, versions_to_delete]) if run_knife_command(cookbook_name, ONE_NO_CONF, versions_to_delete)
+          else
+            versions_to_delete.each do |version|
+              @deleted_cookbooks.push([cookbook_name, version]) if run_knife_command(cookbook_name, ONE_CONF, version)
+            end  
+          end
+        end
+      end
+      # This is the formatted string that the plugins will use to print.
+      @deleted_cookbook_string = ""
+      @deleted_cookbooks.each {|cookbook, version| @deleted_cookbook_string << "#{cookbook}: #{printable_version_string(version)}, " }
+      @deleted_cookbook_string.chop!.chop! # Get rid of the trailing , chop chop!
+      ui.msg("Cookbooks deleted from chef server: #{@deleted_cookbook_string}")
+    end     
+  end
+end

--- a/lib/knife-spork/plugins/campfire.rb
+++ b/lib/knife-spork/plugins/campfire.rb
@@ -16,6 +16,14 @@ EOH
         end
       end
 
+      def after_delete
+        campfire do |rooms|
+          rooms.paste <<-EOH
+"#{organization}#{current_user} deleted the following cookbooks: #{misc_output}"
+EOH
+        end
+      end
+
       def after_promote_remote
         campfire do |rooms|
           rooms.paste <<-EOH

--- a/lib/knife-spork/plugins/eventinator.rb
+++ b/lib/knife-spork/plugins/eventinator.rb
@@ -24,6 +24,18 @@ module KnifeSpork
         end
       end
 
+      def after_delete
+        event_data = {
+          :tag => 'knife',
+          :username => current_user,
+          :status => "#{organization}#{current_user} deleted the following cookbooks: #{misc_output}",
+          :metadata => {
+            :deleted_cookbooks => misc_output
+          }.to_json
+        }
+        eventinate(event_data)
+      end
+
       def after_promote_remote
         environments.each do |environment|
           cookbooks.each do |cookbook|

--- a/lib/knife-spork/plugins/grove.rb
+++ b/lib/knife-spork/plugins/grove.rb
@@ -13,6 +13,12 @@ module KnifeSpork
         EOH
       end
 
+      def after_delete
+        grove <<-EOH
+#{organization}#{current_user} deleted the following cookbooks: #{misc_output}
+        EOH
+      end
+
       def after_promote_remote
         grove <<-EOH
 #{current_user} promoted #{cookbooks.collect{|c| "#{c.name}@#{c.version}"}.join(', ')} on #{environments.collect{|e| "#{e.name}"}.join(', ')}

--- a/lib/knife-spork/plugins/hipchat.rb
+++ b/lib/knife-spork/plugins/hipchat.rb
@@ -11,6 +11,10 @@ module KnifeSpork
         hipchat "#{organization}#{current_user} uploaded the following cookbooks:\n#{cookbooks.collect{ |c| "  #{c.name}@#{c.version}" }.join("\n")}"
       end
 
+      def after_delete
+        hipchat "#{organization}#{current_user} deleted the following cookbooks: #{misc_output}"
+      end
+
       def after_promote_remote
 	      environments.each do |environment|
           diff = environment_diffs[environment.name]

--- a/lib/knife-spork/plugins/irccat.rb
+++ b/lib/knife-spork/plugins/irccat.rb
@@ -7,6 +7,7 @@ module KnifeSpork
 
       TEMPLATES = {
         :upload  => '#BOLD#PURPLECHEF:#NORMAL %{organization}%{current_user} uploaded #TEAL%{cookbooks}#NORMAL',
+        :delete => '#BOLD#PURPLECHEF:#NORMAL %{organization}%{current_user} deleted the following cookbooks: #TEAL%{misc_output}#NORMAL',
         :promote => '#BOLD#PURPLECHEF:#NORMAL %{organization}%{current_user} promoted #TEAL%{cookbooks}#NORMAL to %{environment} %{gist}',
         :environmentfromfile  => '#BOLD#PURPLECHEF:#NORMAL %{organization}%{current_user} uploaded environment #TEAL%{object_name}#NORMAL %{gist}',
         :environmentedit  => '#BOLD#PURPLECHEF:#NORMAL %{organization}%{current_user} edited environment #TEAL%{object_name}#NORMAL %{gist}',
@@ -37,6 +38,14 @@ module KnifeSpork
           :organization => organization,
           :current_user => current_user,
           :cookbooks    => cookbooks.collect { |c| "#{c.name}@#{c.version}" }.join(", ")
+        })
+      end
+
+      def after_delete
+        irccat(template(:delete) % {
+          :organization => organization,
+          :current_user => current_user,
+          :misc_output => misc_output 
         })
       end
 

--- a/lib/knife-spork/plugins/jabber.rb
+++ b/lib/knife-spork/plugins/jabber.rb
@@ -11,6 +11,10 @@ module KnifeSpork
         jabber "#{organization}#{current_user} uploaded the following cookbooks:\n#{cookbooks.collect{ |c| "  #{c.name}@#{c.version}" }.join("\n")}"
       end
 
+      def after_delete
+        jabber "#{organization}#{current_user} deleted the following cookbooks: #{misc_output}"
+      end
+
       def after_promote_remote
         jabber "#{organization}#{current_user} promoted the following cookbooks:\n#{cookbooks.collect{ |c| "  #{c.name}@#{c.version}" }.join("\n")} to #{environments.collect{ |e| "#{e.name}" }.join(", ")}"
       end

--- a/lib/knife-spork/plugins/plugin.rb
+++ b/lib/knife-spork/plugins/plugin.rb
@@ -91,6 +91,10 @@ module KnifeSpork
         @options[:object_difference]
       end
 
+      def misc_output
+        @options[:misc_output]
+      end
+
       def ui
         @options[:ui]
       end

--- a/lib/knife-spork/plugins/slack.rb
+++ b/lib/knife-spork/plugins/slack.rb
@@ -11,6 +11,10 @@ module KnifeSpork
         slack "#{organization}#{current_user} uploaded the following cookbooks:\n#{cookbooks.collect{ |c| "  #{c.name}@#{c.version}" }.join("\n")}"
       end
 
+      def after_delete
+        slack "#{organization}#{current_user} deleted the following cookbooks: #{misc_output}"
+      end
+
       def after_promote_remote
         slack "#{organization}#{current_user} promoted the following cookbooks:\n#{cookbooks.collect{ |c| "  #{c.name}@#{c.version}" }.join("\n")} to #{environments.collect{ |e| "#{e.name}" }.join(", ")}"
       end

--- a/lib/knife-spork/plugins/statusnet.rb
+++ b/lib/knife-spork/plugins/statusnet.rb
@@ -11,6 +11,10 @@ module KnifeSpork
         statusnet "#{organization}#{current_user} uploaded the following cookbooks:\n#{cookbooks.collect{ |c| "  #{c.name}@#{c.version}" }.join("\n")}"
       end
 
+      def after_delete
+        statusnet "#{organization}#{current_user} deleted the following cookbooks: #{misc_output}"
+      end
+
       def after_promote_remote
         statusnet "#{organization}#{current_user} promoted the following cookbooks:\n#{cookbooks.collect{ |c| "  #{c.name}@#{c.version}" }.join("\n")} to #{environments.collect{ |e| "#{e.name}" }.join(", ")}"
       end

--- a/lib/knife-spork/runner.rb
+++ b/lib/knife-spork/runner.rb
@@ -50,6 +50,7 @@ module KnifeSpork
           :object_name => @object_name,
           :object_secondary_name => @object_secondary_name,
           :object_difference => @object_difference,
+          :misc_output => @misc_output,
           :ui => ui
         )
       end


### PR DESCRIPTION
This adds `knife spork delete [COOKBOOKS]` as a command. It keeps it so that `--all` and `--yes` behave the same way they do in the regular `knife cookbook delete` command. 