### PR TITLE
Fix unclear error on non-existant cookbook

### DIFF
--- a/lib/knife-spork/runner.rb
+++ b/lib/knife-spork/runner.rb
@@ -192,7 +192,7 @@ module KnifeSpork
 
       def load_from_berkshelf(name)
         return unless defined?(::Berkshelf)
-        return unless ::File.exist?(self.config[:berksfile])
+        return unless self.config[:berksfile] && ::File.exist?(self.config[:berksfile])
         berksfile = ::Berkshelf::Berksfile.from_file(self.config[:berksfile])
         lockfile = ::Berkshelf::Lockfile.new(berksfile)
 


### PR DESCRIPTION
When there is no berksfile and cookbook to promote can't be found the `knife spork promote` crashes with unclear error:
`ERROR: TypeError: no implicit conversion of nil into String`
