### PR TITLE
Prefer @config[:environment_path] if populated

### DIFF
--- a/lib/knife-spork/runner.rb
+++ b/lib/knife-spork/runner.rb
@@ -110,7 +110,9 @@ module KnifeSpork
       end
 
       def save_environment_changes(environment, json)
-        if spork_config[:environment_path]
+        if @config[:environment_path]
+          environments_path = @config[:environment_path]
+        elsif spork_config[:environment_path]
           environments_path = spork_config[:environment_path]
         else
           split_cb_path = cookbook_path.split("/")


### PR DESCRIPTION
Hi,

As discussed at the Summit I want to use spork to promote cookbooks via CI and am hoping to make this work without a `spork-config.yml`.  I've hit an issue when specifying the `environment_path` via  `--config-option` where it uses the wrong path to write the file:

```
~/c/demo_cookbook ❯❯❯ knife spork promote $CI_ENVIRONMENT_NAME $CI_PROJECT_NAME --config-option environment_path=`pwd`
Adding version constraint demo_cookbook = 1.1.0
Saving changes to demo_env.json
ERROR: Errno::ENOENT: No such file or directory @ rb_sysopen - /Users/shoekstra/environments/demo_env.json
```

This patch fixes this by preferring the option passed to `--config-option`.