### PR TITLE
fixing save_environment_changes method on Knife::Runner::InstanceMethods

### DIFF
--- a/lib/knife-spork/runner.rb
+++ b/lib/knife-spork/runner.rb
@@ -110,7 +110,9 @@ module KnifeSpork
       end
 
       def save_environment_changes(environment, json)
-        if @config[:environment_path]
+        if spork_config[:environment_path]
+          environments_path = spork_config[:environment_path]
+        elsif @config[:environment_path]
           # environment_path can be an Array or String. If Array, let's just
           # take the first value as we have done in other similar circumstances
           environments_path = if @config[:environment_path].is_a? Array
@@ -118,9 +120,6 @@ module KnifeSpork
                               else
                                 @config[:environment_path]
                               end
-
-        elsif spork_config[:environment_path]
-          environments_path = spork_config[:environment_path]
         else
           split_cb_path = cookbook_path.split("/")
           environments_path = (split_cb_path[0..-2] << split_cb_path[-1].gsub("cookbooks","environments")).join("/")

--- a/lib/knife-spork/runner.rb
+++ b/lib/knife-spork/runner.rb
@@ -38,7 +38,7 @@ module KnifeSpork
 
         environments = [ @environments || @environment ].flatten.compact.collect{|environment| environment.is_a?(::Chef::Environment) ? environment : load_environment_from_file(environment)}.sort{|a,b| a.name.to_s <=> b.name.to_s}
         environment_diffs = @environment_diffs
-        
+
         KnifeSpork::Plugins.run(
           :config => spork_config,
           :hook => hook.to_sym,
@@ -57,7 +57,7 @@ module KnifeSpork
 
       def load_environments_and_cookbook
         ensure_environment_and_cookbook_provided!
-       
+
         if @name_args.size == 2
           environments = @name_args[0].split(",").map{ |env| load_specified_environment_group(env) }
           [ environments.flatten, @name_args[1] ]
@@ -111,7 +111,14 @@ module KnifeSpork
 
       def save_environment_changes(environment, json)
         if @config[:environment_path]
-          environments_path = @config[:environment_path]
+          # environment_path can be an Array or String. If Array, let's just
+          # take the first value as we have done in other similar circumstances
+          environments_path = if @config[:environment_path].is_a? Array
+                                @config[:environment_path].first
+                              else
+                                @config[:environment_path]
+                              end
+
         elsif spork_config[:environment_path]
           environments_path = spork_config[:environment_path]
         else
@@ -250,7 +257,7 @@ module KnifeSpork
         begin
           environment_loader.object_from_file("#{environment_path}/#{environment_name}.json")
         rescue FFI_Yajl::ParseError => e
-          raise "#{environment_name} environment file has syntactically incorrect json.\n #{e.to_s}" 
+          raise "#{environment_name} environment file has syntactically incorrect json.\n #{e.to_s}"
         end
       end
 


### PR DESCRIPTION
Chef::Config[:environment_path] can be an Array or String. If Array, this method will produce undesirable results. The subsequent File.join method will expand to a path that just doesn't exist. This PR fixes this issue by checking the type and selecting the first path if an Array of paths are specified. 

This situation will happen automatically if an Array is passed to Chef::Config[:cookbook_path], which is completely valid. See the following:

* https://github.com/chef/chef/blob/45f1c23c3d5b5a78bff9b88292f908c94eea71ec/chef-config/lib/chef-config/config.rb#L233
* https://github.com/chef/chef/blob/45f1c23c3d5b5a78bff9b88292f908c94eea71ec/chef-config/lib/chef-config/config.rb#L187-L193

Furthermore, if a user sets environment_path in spork's configuration. It should get picked up instead of whatever is set in the Chef::Config