### PR TITLE
Add `--fail-if-frozen` flag to `spork check`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+Features:
+
+    - Added `--fail-if-frozen` flag to `knife spork check` to only fail when local version matches a frozen version
+
+
 ## 1.7.2 (3rd August 2018)
     
 Bugfixes:

--- a/lib/chef/knife/spork-check.rb
+++ b/lib/chef/knife/spork-check.rb
@@ -18,6 +18,10 @@ module KnifeSpork
       :long => "--fail",
       :description => "If the check fails exit with non-zero exit code"
 
+    option :fail_if_frozen,
+      :long => "--fail-if-frozen",
+      :description => "If the check fails exit with non-zero exit code when cookbook is frozen"
+
     option :cookbook_path,
       :short => '-o PATH:PATH',
       :long => '--cookbook-path PATH:PATH',
@@ -85,7 +89,7 @@ module KnifeSpork
           if frozen?(remote_version)
             message = "Your local version (#{local_version}) is frozen on the remote server. You'll need to bump before you can upload."
             message_autobump = "Your local version (#{local_version}) is frozen on the remote server. Autobumping so you can upload."
-            if config[:fail]
+            if config[:fail] || config[:fail_if_frozen]
               fail_and_exit("#{message}")
             else
               answer = nil
@@ -104,7 +108,7 @@ module KnifeSpork
               end
             end
           else
-            message =  "The version #{local_version} exists on the server and is not frozen. Uploading will overwrite!"
+            message = "The version #{local_version} exists on the server and is not frozen. Uploading will overwrite!"
             config[:fail] ? fail_and_exit("#{message}") : ui.error("#{message}")
           end
 


### PR DESCRIPTION
Hi!

Sometimes you would like to overwrite a cookbook if it's not frozen, like in the case where your cookbooks are uploaded to the Chef server via a CI job you find yourself in a situation where you want to push more commits before freezing, but doing so retriggers the CI pipeline and the `knife spork check` job fails.  

This PR adds a `--fail-if-frozen` flag to still return `0` if a cookbook is not frozen.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>